### PR TITLE
Fixing warning about uninitialized variable

### DIFF
--- a/SpineImporter/SGG_SpineBoneAction.m
+++ b/SpineImporter/SGG_SpineBoneAction.m
@@ -679,7 +679,7 @@
 	NSArray* roots = [self solveCubicEquationWithA:a andB:b andC:c andD:d];
 	
 
-	double closest;
+	double closest = 0;
 
 	for (int i = 0; i < roots.count; i++) {
 		double root = [roots[i] doubleValue];


### PR DESCRIPTION
Cleaning up a small warning in SGG_SpineBoneAction.m.
