### PR TITLE
Feat/skin names as atlas names

### DIFF
--- a/SpineImporter/SGG_Spine.h
+++ b/SpineImporter/SGG_Spine.h
@@ -46,6 +46,7 @@ typedef enum {
 @property (nonatomic, strong) NSArray* slotsArray; //raw array from json
 @property (nonatomic, strong) NSDictionary* rawAnimationDictionary; //raw information from JSON
 
+-(void)skeletonFromFileNamed:(NSString*)name andUseSkinNamed:(NSString*)skinName;
 -(void)skeletonFromFileNamed:(NSString*)name andAtlasNamed:(NSString*)atlasName andUseSkinNamed:(NSString*)skinName;
 
 -(void)runAnimation:(NSString*)animationName andCount:(NSInteger)count withIntroPeriodOf:(const CGFloat)introPeriod andUseQueue:(BOOL)useQueue;

--- a/SpineImporter/SGG_Spine.h
+++ b/SpineImporter/SGG_Spine.h
@@ -46,7 +46,10 @@ typedef enum {
 @property (nonatomic, strong) NSArray* slotsArray; //raw array from json
 @property (nonatomic, strong) NSDictionary* rawAnimationDictionary; //raw information from JSON
 
+// this method assumes the image assets are in an atlas with the same name as the skin. This allows you to have seperate asset folders for each skin in Spine.
+// if you want to provide atlasName, use skeletonFromFileNamed:andAtlasNamed:andUseSkinNamed:
 -(void)skeletonFromFileNamed:(NSString*)name andUseSkinNamed:(NSString*)skinName;
+
 -(void)skeletonFromFileNamed:(NSString*)name andAtlasNamed:(NSString*)atlasName andUseSkinNamed:(NSString*)skinName;
 
 -(void)runAnimation:(NSString*)animationName andCount:(NSInteger)count withIntroPeriodOf:(const CGFloat)introPeriod andUseQueue:(BOOL)useQueue;

--- a/SpineImporter/SGG_Spine.m
+++ b/SpineImporter/SGG_Spine.m
@@ -744,6 +744,7 @@
                 if (pullAtlasNamesFromSkinNames) {
                     NSArray<NSString*> *components = [spriteNameString componentsSeparatedByString:@"/"];
                     if (components.count) {
+                        // if you have seperate folders for assets of each skin in Spine, you should not see this warning 
                         if (![components[0] isEqualToString:skinName])
                             NSLog(@"Warn: I was expecting the skinName to be the folder/atlas name");
                         spriteNameString = components[components.count-1];


### PR DESCRIPTION
This update adds the functionality of using skin names are image asset folder names in Spine. 

Assume you have images/skin1 and images/skin2 folder which each folder has all assets for skin1 and skin2. When you just drag the files to skin attachments, you will have skin1/asset as the name. If you just name skin1 folder as skin1.atlas and add to your xcode project, this code delta will let you call skeletonFromFileNamed:andUseSkinNamed: and all work properly.

I hope this is making it easier to export and use your Spine project. 
